### PR TITLE
Fix broken Salesforce extraction DAG

### DIFF
--- a/Dockerfile.salesforce
+++ b/Dockerfile.salesforce
@@ -18,7 +18,7 @@ COPY --chown=airflow:root pyproject.salesforce.toml ./pyproject.toml
 
 # Install dependencies using UV as root (--system requires root permissions)
 # This image only contains dependencies needed for Salesforce extraction
-RUN uv pip install --system -r pyproject.toml
+RUN uv pip install --system --no-cache .
 
 # Switch to airflow user for runtime
 USER airflow

--- a/pyproject.salesforce.toml
+++ b/pyproject.salesforce.toml
@@ -1,6 +1,9 @@
 # Salesforce-specific dependencies
 # This allows you to create minimal images for each DAG
-# Note: No [build-system] - we're only using this for dependency management, not building a package
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "de-airflow-pipeline-salesforce"
 version = "0.1.0"
@@ -12,3 +15,7 @@ dependencies = [
     "pandas==2.1.4",
     "psycopg2-binary==2.9.9",
 ]
+
+[tool.setuptools]
+# Don't discover any packages - we're only using this for dependency installation
+py-modules = []


### PR DESCRIPTION
The Dockerfile was using '-r pyproject.toml' which is the syntax for requirements.txt files, not pyproject.toml. This caused dependencies (including apache-airflow-providers-salesforce) to not be installed, resulting in ModuleNotFoundError when running the DAG.

Changed to 'uv pip install --system --no-cache .' which correctly installs the project and its dependencies from pyproject.toml.